### PR TITLE
Added the PINGREQ and the PINGRESP packet

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -30,3 +30,18 @@ pub async fn read_connack(stream: &mut TcpStream) -> Result<bool, Box<dyn std::e
         Ok(false)
     }
 }
+
+pub async fn read_pingresp(stream: &mut TcpStream) -> Result<bool, Box<dyn std::error::Error>> {
+    println!("Reading PINGRESP");
+    
+    let mut buffer = [0u8; 2];
+    stream.read_exact(&mut buffer).await?; 
+    println!("{:?}", buffer);
+    if buffer[0] == 0xD0 && buffer[1] == 0x00 {
+        Ok(true)
+    } else {
+        Ok(false)
+
+    }
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod packet;
 mod client;
-use packet::{MqttConnect, MqttPublish};
+use client::read_pingresp;
+use packet::{MqttConnect, MqttPublish, MqttPingReq};
+use tokio::time::{sleep, Duration};
 use client::connect_to_broker;
 use client::read_connack;
 use tokio::io::AsyncWriteExt;
@@ -25,11 +27,32 @@ async fn main() {
 
                 stream.write_all(&publish_packet).await.unwrap();
                 println!("Published message!");
+
+                let keep_alive_int = Duration::from_secs(60);
+                tokio::spawn(async move{
+                    loop {
+                        sleep(keep_alive_int).await;
+
+                        let pingreq_packet = MqttPingReq {}.encode();
+                        if let Err(e) = stream.write_all(&pingreq_packet).await {
+                            eprintln!("Failed to send PINGREQ packet");
+                            break;
+                        }
+                        println!("Sent PINGREQ");
+
+                        if let Err(e) = read_pingresp(&mut stream).await {
+                            eprintln!("Failed to read PINGRESP: {}", e);
+                            break;
+                        }
+    
+                        println!("Received PINGRESP");
+                    }
+                }).await.unwrap();
             }
 
         }
         Err(e) => {
             eprintln!("Failed to connect to the broker: {}", e);
         }
-    }
+    }   
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -2,6 +2,7 @@ pub enum PacketType {
     Connect = 1,
     ConnAck = 2,
     Publish = 3,
+    PingReq = 12,
 }
 pub struct MqttConnect {
     protocol_name: String,
@@ -10,18 +11,11 @@ pub struct MqttConnect {
     client_id: String,
 }
 
-pub struct ConnectPacket {
-    protocol_name: String,
-    protocol_level: u8,
-    client_id: String,
-    keep_alive: u16,
-}
-
 impl MqttConnect {
     pub fn new(client_id: &str) -> Self {
         Self {
             protocol_name: "MQTT".to_string(),
-            protocol_level: 4,
+            protocol_level: 4, // 4 is MQTT 3.1.1
             clean_session: true,
             client_id: client_id.to_string(),
         }
@@ -61,6 +55,20 @@ impl MqttConnect {
     }
 }
 
+
+
+pub struct MqttPingReq{
+
+}
+
+impl MqttPingReq{
+    pub fn encode(&self) -> Vec<u8> {
+        let mut packet = Vec::new();
+        packet.push((PacketType::PingReq as u8) << 4);
+        packet.push(0x00); // Remaining length is 0 for PINGREQ
+        packet
+    }
+}
 pub struct MqttPublish {
     pub topic: String,
     pub payload: Vec<u8>,
@@ -69,7 +77,7 @@ pub struct MqttPublish {
 impl MqttPublish {
     pub fn encode(&self) -> Vec<u8> {
         let mut packet = Vec::new();
-        packet.push((PacketType::Connect as u8) << 4); // PUBLISH packet type
+        packet.push((PacketType::Publish as u8) << 4); // PUBLISH packet type
 
         // We need to add remaining length (simplified, assumes small packets)
         packet.push((self.topic.len() + self.payload.len() + 2) as u8);
@@ -81,7 +89,6 @@ impl MqttPublish {
 
         // Payload
         packet.extend_from_slice(&self.payload);
-        
         packet
     }
 }


### PR DESCRIPTION
This pull request introduces functionality for handling MQTT `PINGREQ` and `PINGRESP` packets, along with some code cleanup and refactoring. The most important changes include the addition of a new function to read `PINGRESP` packets, modifications to the main event loop to handle keep-alive messages, and updates to the `packet` module to support `PINGREQ` packets.

### MQTT Keep-Alive Functionality:

* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R33-R47): Added `read_pingresp` function to read `PINGRESP` packets from the stream.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR30-R50): Modified the main event loop to send `PINGREQ` packets periodically and handle `PINGRESP` packets.

### Packet Type Enhancements:

* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bR5): Added `PingReq` to the `PacketType` enum.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bR58-R71): Implemented the `MqttPingReq` struct with an `encode` method to create `PINGREQ` packets.

### Code Cleanup:

* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL72-R80): Corrected the packet type used in the `MqttPublish` struct's `encode` method.