### PR TITLE
Fixing event loop and concurrency issues

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,5 @@
 use tokio::net::TcpStream;
 use tokio::io::{AsyncWriteExt, AsyncReadExt};
-
-use crate::packet::PacketType;
 use crate::packet::MqttConnect;
 
 // Connect to the MQTT Broker via TCP/IP
@@ -32,8 +30,6 @@ pub async fn read_connack(stream: &mut TcpStream) -> Result<bool, Box<dyn std::e
 }
 
 pub async fn read_pingresp(stream: &mut TcpStream) -> Result<bool, Box<dyn std::error::Error>> {
-    println!("Reading PINGRESP");
-    
     let mut buffer = [0u8; 2];
     stream.read_exact(&mut buffer).await?; 
     println!("{:?}", buffer);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,13 @@ mod packet;
 mod client;
 use client::read_pingresp;
 use packet::{MqttConnect, MqttPublish, MqttPingReq};
+
+use tokio::time::timeout;
+
 use tokio::time::{sleep, Duration};
 use client::connect_to_broker;
 use client::read_connack;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::main]
 
@@ -18,36 +21,49 @@ async fn main() {
         Ok(mut stream) => {
             if let Ok(true) = read_connack(&mut stream).await {
                 println!("Connected to the broker!");
-                
-                // Send a PUBLISH packet
-                let publish_packet = MqttPublish {
-                    topic: "test/topic".to_string(),
-                    payload: b"Hello MQTT!".to_vec(),
-                }.encode();
 
-                stream.write_all(&publish_packet).await.unwrap();
-                println!("Published message!");
+                // SUBSCRIPTION PACKETS TO BE SENT AT THE BEGINNING
 
-                let keep_alive_int = Duration::from_secs(60);
-                tokio::spawn(async move{
-                    loop {
-                        sleep(keep_alive_int).await;
+                let keep_alive_int = Duration::from_secs(5);
+                let mut last_ping = tokio::time::Instant::now();
 
+                loop {
+                    // Check if it's time to send a PINGREQ
+                    if last_ping.elapsed() >= keep_alive_int {
                         let pingreq_packet = MqttPingReq {}.encode();
                         if let Err(e) = stream.write_all(&pingreq_packet).await {
-                            eprintln!("Failed to send PINGREQ packet");
+                            eprintln!("Failed to send PINGREQ packet: {}", e);
                             break;
                         }
                         println!("Sent PINGREQ");
-
-                        if let Err(e) = read_pingresp(&mut stream).await {
-                            eprintln!("Failed to read PINGRESP: {}", e);
+                        last_ping = tokio::time::Instant::now();
+                    }
+                    
+                    let mut buffer = [0u8; 2];
+                    match timeout(Duration::from_secs(1), stream.read_exact(&mut buffer)).await {
+                        Ok(Ok(_)) => match buffer[0] >> 4 {
+                            13 => {
+                                println!("Received PINGRESP");
+                            }
+                            _ => {
+                                println!("Received unknown packet type {:?}", buffer);
+                            }
+                        },
+                        Ok(Err(e)) => {
+                            eprintln!("Failed to read packet: {:?}", e);
                             break;
                         }
-    
-                        println!("Received PINGRESP");
+                        Err(_) => {
+                            // Timeout expired
+                            println!("Nothing is in the stream.");
+                        }
                     }
-                }).await.unwrap();
+                    
+                    
+                    sleep(Duration::from_millis(100)).await;
+                }
+            } else {
+                eprintln!("Failed to receive CONNACK; Can't connect to broker.");
             }
 
         }


### PR DESCRIPTION
 The most important changes in this PR include adding timeout handling for reading packets to fix a bug where indefinite blocking occured, and restructuring the main loop to handle PINGREQ and PINGRESP more efficiently.

Error handling and timeout improvements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL22-R66): Added timeout handling for reading packets in the main loop to avoid indefinite blocking.

Restructuring main loop:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL22-R66): Modified the main loop to send PINGREQ packets at regular intervals and handle PINGRESP packets more robustly, including logging and error handling.