### PR TITLE
SUBSCRIBE and SUBACK packets packet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,8 @@ async fn main() {
                     id:1,
                 }.encode();
                 println!("{:?}", subscription_packet);
-
+                
+                // One thing to note is that SUBACK packets could be checked here before entering the main loop
                 if let Err(e) = stream.write_all(&subscription_packet).await{
                     eprintln!("Failed to subscribe: {}", e);
                 } else{

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -65,7 +65,7 @@ pub struct MqttPingReq{
 impl MqttPingReq{
     pub fn encode(&self) -> Vec<u8> {
         let mut packet = Vec::new();
-        packet.push(((PacketType::PingReq as u8) << 4));
+        packet.push((PacketType::PingReq as u8) << 4);
         packet.push(0x00); // Remaining length is 0 for PINGREQ
         packet
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -2,6 +2,7 @@ pub enum PacketType {
     Connect = 1,
     ConnAck = 2,
     Publish = 3,
+    Subscribe = 8,
     PingReq = 12,
 }
 pub struct MqttConnect {
@@ -64,31 +65,90 @@ pub struct MqttPingReq{
 impl MqttPingReq{
     pub fn encode(&self) -> Vec<u8> {
         let mut packet = Vec::new();
-        packet.push((PacketType::PingReq as u8) << 4);
+        packet.push(((PacketType::PingReq as u8) << 4));
         packet.push(0x00); // Remaining length is 0 for PINGREQ
+        packet
+    }
+}
+
+
+pub struct MqttSubscribe{
+    pub topic: String,
+    pub id: u16,
+}
+impl MqttSubscribe{
+    pub fn encode(&self) -> Vec<u8> {
+        let mut packet = Vec::new();
+        packet.push(((PacketType::Subscribe as u8) << 4) + 2);
+        packet.push((self.topic.len() + 5) as u8);
+
+        // Packet ID
+        packet.push((self.id >> 8) as u8); // MSB Packet ID
+        packet.push((self.id & 0xFF) as u8); // LSB Packet ID
+        // Payload
+        let topic_len = self.topic.len();
+        packet.push((topic_len >> 8) as u8); // MSB Length
+        packet.push((topic_len & 0xFF) as u8); // LSB Length
+        packet.extend_from_slice(self.topic.as_bytes());
+
+        // QoS Level
+        packet.push(0); 
+
         packet
     }
 }
 pub struct MqttPublish {
     pub topic: String,
     pub payload: Vec<u8>,
+    pub dup: bool,
+    pub retain: bool
 }
 
 impl MqttPublish {
     pub fn encode(&self) -> Vec<u8> {
         let mut packet = Vec::new();
-        packet.push((PacketType::Publish as u8) << 4); // PUBLISH packet type
+        let mut fixed_header = 0;
 
-        // We need to add remaining length (simplified, assumes small packets)
+        fixed_header |= (PacketType::Publish as u8) << 4;
+
+        if self.dup {
+            fixed_header |= 0x08;
+        }
+
+        fixed_header |= (0 & 0x03) << 1; // To be changed in the future for QoS implementations
+
+        if self.retain {
+            fixed_header |= 0x01;
+        }
+        packet.push(fixed_header);
         packet.push((self.topic.len() + self.payload.len() + 2) as u8);
 
         // Topic
-        packet.push(0);
-        packet.push(self.topic.len() as u8);
+        let topic_len = self.topic.len();
+        packet.push((topic_len >> 8) as u8);
+        packet.push((topic_len & 0xFF) as u8);
         packet.extend_from_slice(self.topic.as_bytes());
 
         // Payload
         packet.extend_from_slice(&self.payload);
+
+        let remaining_length = packet.len() - 1; // Exclude the fixed header byte
+        let mut remaining_length_bytes = Vec::new();
+        let mut x = remaining_length;
+        loop {
+            let mut encoded_byte = (x % 128) as u8;
+            x /= 128;
+            if x > 0 {
+                encoded_byte |= 128;
+            }
+            remaining_length_bytes.push(encoded_byte);
+            if x == 0 {
+                break;
+            }
+        }
+
+        
+        packet.splice(1..1, remaining_length_bytes.iter().cloned());
         packet
     }
-}
+} 


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the MQTT client implementation in `src/main.rs` and `src/packet.rs`. The key changes include adding support for MQTT subscriptions, improving packet handling, and updating connection parameters.

### MQTT Subscription Support:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL16-R72): Added support for subscribing to topics upon connection, including encoding and sending `MqttSubscribe` packets and handling `SUBACK` responses.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bR73-R151): Introduced the `MqttSubscribe` struct with an `encode` method to facilitate subscription packet creation.

### Packet Handling Enhancements:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL46-R98): Improved packet type handling in the main loop, including decoding `PUBLISH` packets and differentiating between known and unknown packet types.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bR73-R151): Enhanced the `MqttPublish` struct to include `dup` and `retain` flags and updated the `encode` method to handle these flags.

### Connection Parameter Updates:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL16-R72): Changed the MQTT broker address and client ID for better testing and added a longer keep-alive interval to maintain the connection.