### PR TITLE
Decoding PUBLISH payload strings working

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,15 +84,22 @@ async fn main() {
                         last_ping = tokio::time::Instant::now();
                     }
                     
-                    let mut buffer = [0u8; 2];
+                    let mut buffer = [0u8; 1];
                     match timeout(Duration::from_secs(1), stream.read_exact(&mut buffer)).await {
                         Ok(Ok(_)) => match buffer[0] >> 4 {
                             13 => {
                                 println!("Received PINGRESP packet.");
                             }
                             3 => {
-                                println!("Received PUBLISH packet.")
-                                // Decoding of publish packet
+                                
+                                let received_publish = MqttPublish::decode(buffer.to_vec(), &mut stream);
+                                let pub_struct = received_publish.await;
+                                println!("Received PUBLISH packet.");
+                                println!("-------------------------------");
+                                println!("Topic: {}", pub_struct.topic);
+                                println!("Payload: {}", pub_struct.payload);
+                                println!("-------------------------------");
+
                             }
                             _ => {
                                 println!("Received unknown packet type {:?}", buffer[0] >> 4);
@@ -106,9 +113,7 @@ async fn main() {
                             // Timeout expired
                             println!("Nothing is in the stream.");
                         }
-                    }
-                    
-                    
+                    }    
                     sleep(Duration::from_millis(100)).await;
                 }
          


### PR DESCRIPTION
This pull request introduces several key changes to the MQTT packet handling in the `src/main.rs` and `src/packet.rs` files. The changes include improvements to packet decoding, adjustments to buffer sizes, and enhancements to the `MqttPublish` struct and its methods.

### Packet Handling Enhancements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL87-R102): Modified the buffer size from 2 bytes to 1 byte and added detailed logging for the `PUBLISH` packet, including decoding the packet and printing the topic and payload.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bR1-R4): Added necessary imports for `TcpSocket`, `TcpStream`, `AsyncReadExt`, and `AsyncWriteExt` to support asynchronous operations.

### `MqttPublish` Struct Enhancements:

* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL102-R121): Updated the `MqttPublish` struct to include a `qos` field and changed the `payload` type from `Vec<u8>` to `String`.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL102-R121): Added a new constructor method `new` for initializing `MqttPublish` instances with all necessary fields.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL150-R223): Implemented a new `decode` method for `MqttPublish` to asynchronously decode a packet from a TCP stream, extracting the topic and payload.