### PR TITLE
Polishing Up API Output

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,7 @@
-use bytes::buf;
 use tokio::net::TcpStream;
 use tokio::io::{AsyncWriteExt, AsyncReadExt};
 use crate::packet::{MqttConnect, MqttPublish, MqttSubscribe};
-use tokio::time::{sleep, Duration, timeout};
+use tokio::time::{Duration, timeout};
 // Connect to the MQTT Broker via TCP/IP
 pub async fn connect_to_broker(broker: &str, port: u16, client_id: &str) -> tokio::io::Result<TcpStream> {
     println!("Connecting to broker at {}:{}", broker, port);
@@ -20,8 +19,7 @@ pub async fn connect_to_broker(broker: &str, port: u16, client_id: &str) -> toki
 
 
 pub async fn send_publish_message(stream: &mut TcpStream, payload: String, topic: String){
-    let packet_structure = MqttPublish::new(topic, payload, true, 0, false);
-    let encoded_packet = packet_structure.encode();
+    let encoded_packet = MqttPublish::new(topic, payload, true, 0, false).encode();
     if let Err(e) = stream.write_all(&encoded_packet).await {
         println!("Error occurred when sending PUBLISH packet: {}", e);
     } else {
@@ -45,13 +43,15 @@ pub async fn subscribe_to_topic(stream: &mut TcpStream, topic: &str, id:u16){
                 match buffer[0] >> 4 {
                     9 => { // SUBACK packet type
                         println!("Received SUBACK for {}", topic);
+                        println!("-------------------------------");
                         // Check the return code in the SUBACK packet
                         let return_code = buffer[3]; // Adjust index based on actual packet structure
                         if return_code == 0x00 || return_code == 0x01 {
-                            println!("Subscription to {} successful!", topic);
+                            println!("Status: Subscription to {} successful!", topic);
                         } else {
-                            println!("Subscription to {} failed with return code: {}", topic, return_code);
+                            println!("Status: Subscription to {} failed with return code: {}", topic, return_code);
                         }
+                        println!("-------------------------------");
                     }
                     _ => {
                         println!("Received unexpected packet type {:?}", buffer[0] >> 4);

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,6 @@ pub async fn send_publish_message(stream: &mut TcpStream, payload: String, topic
 
 pub async fn subscribe_to_topic(stream: &mut TcpStream, topic: &str, id:u16){
     let encoded_packet = MqttSubscribe::new(topic.to_string(), id).encode();
-    println!("{:?}", encoded_packet);
     if let Err(e) = stream.write_all(&encoded_packet).await {
         println!("Error occurred when sending SUBSCRIBE packet: {}", e);
     } else {
@@ -39,7 +38,6 @@ pub async fn subscribe_to_topic(stream: &mut TcpStream, topic: &str, id:u16){
         let mut buffer = [0u8; 4]; 
         match timeout(Duration::from_secs(1), stream.read_exact(&mut buffer)).await {
             Ok(Ok(_)) => {
-                println!("Received raw packet data: {:?}", &buffer);
                 match buffer[0] >> 4 {
                     9 => { // SUBACK packet type
                         println!("Received SUBACK for {}", topic);

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,7 @@ pub async fn send_publish_message(stream: &mut TcpStream, payload: String, topic
 }
 
 pub async fn subscribe_to_topic(stream: &mut TcpStream, topic: &str, id:u16){
+    println!("Trying to subscribe to {}", topic);
     let encoded_packet = MqttSubscribe::new(topic.to_string(), id).encode();
     if let Err(e) = stream.write_all(&encoded_packet).await {
         println!("Error occurred when sending SUBSCRIBE packet: {}", e);
@@ -103,7 +104,7 @@ pub async fn run_main_loop(mut stream: &mut TcpStream, subscriptions: Vec<&str>)
             subscribe_to_topic(&mut stream, sub, counter).await;
             counter += 1;
         } 
-        
+
         let keep_alive_int = Duration::from_secs(60);
         let mut last_ping = tokio::time::Instant::now();
         loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ async fn main() {
     let port = 1883;
     let client_id = "minqtt_client";
     let mut subscriptions = Vec::new();
+    
     subscriptions.push("sub1");
     subscriptions.push("RAG");
     subscriptions.push("sub2");

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,6 @@ async fn main() {
                         }
                         Err(_) => {
                             // Timeout expired
-                            println!("Nothing is in the stream.");
                         }
                     }    
                     sleep(Duration::from_millis(100)).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,9 @@
 mod packet;
 mod client;
-use packet::{MqttPublish, MqttPingReq};
+use client::{connect_to_broker, run_main_loop};
 
-use tokio::time::timeout;
-
-use tokio::time::{sleep, Duration};
-use client::{connect_to_broker, read_pingresp, subscribe_to_topic};
-use client::read_connack;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::main]
-
 async fn main() {
     let broker = "test.mosquitto.org";
     let port = 1883;
@@ -22,70 +15,7 @@ async fn main() {
 
     match connect_to_broker(broker, port, client_id).await {
         Ok(mut stream) => {
-            if let Ok(true) = read_connack(&mut stream).await {
-                println!("Connected to the broker!");
-                let mut counter = 1;
-                for sub in subscriptions{
-                    subscribe_to_topic(&mut stream, sub, counter).await;
-                    counter += 1;
-                } 
-           
-                sleep(Duration::from_millis(1000)).await;
-            
-                let keep_alive_int = Duration::from_secs(60);
-                let mut last_ping = tokio::time::Instant::now();
-                loop {
-                    // Check if it's time to send a PINGREQ
-                    if last_ping.elapsed() >= keep_alive_int {
-                        let pingreq_packet = MqttPingReq {}.encode();
-                        if let Err(e) = stream.write_all(&pingreq_packet).await {
-                            eprintln!("Failed to send PINGREQ packet: {}", e);
-                            break;
-                        }
-                        println!("Sent PINGREQ");
-                        last_ping = tokio::time::Instant::now();
-                    }
-                    
-                    let mut buffer = [0u8; 1];
-                    match timeout(Duration::from_secs(1), stream.read_exact(&mut buffer)).await {
-                        Ok(Ok(_)) => match buffer[0] >> 4 {
-                            13 => {
-                                if let Ok(true) = read_pingresp(&mut stream).await {
-                                    println!("Received PINGRESP packet.");
-                                }
-                                else{
-                                    println!("Error regarding PINGRESP packet.");
-                                }
-                                
-                            }
-                            3 => {
-                                println!("Received PUBLISH packet.");
-                                let received_publish = MqttPublish::decode(buffer.to_vec(), &mut stream);
-                                let pub_struct = received_publish.await;
-                                println!("-------------------------------");
-                                println!("Topic: {}", pub_struct.topic);
-                                println!("Payload: {}", pub_struct.payload);
-                                println!("-------------------------------");
-                            }
-                            _ => {
-                                println!("Received unknown packet type {:?}", buffer[0] >> 4);
-                            }
-                        },
-                        Ok(Err(e)) => {
-                            eprintln!("Failed to read packet: {:?}", e);
-                            break;
-                        }
-                        Err(_) => {
-                            // Timeout expired
-                        }
-                    }    
-                    sleep(Duration::from_millis(100)).await;
-                }
-         
-            } else {
-                eprintln!("Failed to receive CONNACK; Can't connect to broker.");
-            }
-
+            run_main_loop(&mut stream, subscriptions).await;
         }
         Err(e) => {
             eprintln!("Failed to connect to the broker: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
         Ok(mut stream) => {
             if let Ok(true) = read_connack(&mut stream).await {
                 println!("Connected to the broker!");
-                let mut counter = 0;
+                let mut counter = 1;
                 for sub in subscriptions{
                     subscribe_to_topic(&mut stream, sub, counter).await;
                     counter += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod packet;
 mod client;
-use packet::{MqttConnect, MqttPublish, MqttPingReq, MqttSubscribe};
+use packet::{MqttPublish, MqttPingReq};
 
 use tokio::time::timeout;
 
@@ -12,11 +12,12 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 #[tokio::main]
 
 async fn main() {
-    let broker = "broker.hivemq.com";
+    let broker = "test.mosquitto.org";
     let port = 1883;
     let client_id = "minqtt_client";
     let mut subscriptions = Vec::new();
     subscriptions.push("sub1");
+    subscriptions.push("RAG");
     subscriptions.push("sub2");
 
     match connect_to_broker(broker, port, client_id).await {
@@ -31,9 +32,8 @@ async fn main() {
            
                 sleep(Duration::from_millis(1000)).await;
             
-                let keep_alive_int = Duration::from_secs(2);
+                let keep_alive_int = Duration::from_secs(60);
                 let mut last_ping = tokio::time::Instant::now();
-
                 loop {
                     // Check if it's time to send a PINGREQ
                     if last_ping.elapsed() >= keep_alive_int {
@@ -59,10 +59,9 @@ async fn main() {
                                 
                             }
                             3 => {
-                                
+                                println!("Received PUBLISH packet.");
                                 let received_publish = MqttPublish::decode(buffer.to_vec(), &mut stream);
                                 let pub_struct = received_publish.await;
-                                println!("Received PUBLISH packet.");
                                 println!("-------------------------------");
                                 println!("Topic: {}", pub_struct.topic);
                                 println!("Payload: {}", pub_struct.payload);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,6 +1,6 @@
 
-use tokio::net::{TcpSocket, TcpStream};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream};
+use tokio::io::{AsyncReadExt};
 
 pub enum PacketType {
     Connect = 1,
@@ -78,9 +78,15 @@ impl MqttPingReq{
 
 pub struct MqttSubscribe{
     pub topic: String,
-    pub id: u16,
+    pub id: u16, // To be fixed later - ID is used to identify packets whilst being in acknowledgement process (Some kind of DHCP but for IDs?)
 }
 impl MqttSubscribe{
+    pub fn new(topic:String, id:u16) -> Self{
+        MqttSubscribe{
+            topic,
+            id
+        }
+    }
     pub fn encode(&self) -> Vec<u8> {
         let mut packet = Vec::new();
         packet.push(((PacketType::Subscribe as u8) << 4) + 2);
@@ -171,7 +177,6 @@ impl MqttPublish {
         let dup = (fixed_header & 0x08) != 0;
         let retain = (fixed_header & 0x01) != 0;
 
-        let mut index = 1;
         let mut remaining_length = 0;
         let mut multiplier = 1;
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,6 +1,6 @@
 
-use tokio::net::{TcpStream};
-use tokio::io::{AsyncReadExt};
+use tokio::net::TcpStream;
+use tokio::io::AsyncReadExt;
 
 pub enum PacketType {
     Connect = 1,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -189,7 +189,7 @@ impl MqttPublish {
                     remaining_length += (byte & 127) as usize * multiplier;
                     multiplier *= 128;
                     if byte & 128 == 0 {
-                        break;
+                        break; // All remanining length bytes have been read when MSB is 0
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
This pull request introduces several new features and improvements to the MQTT client, including support for publishing and subscribing to topics, enhanced error handling, and code cleanup. The most important changes are outlined below:

### New Features:
* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R21-R72): Added functions `send_publish_message`, `subscribe_to_topic`, and `subscribe_to_topic_vector` to support publishing messages and subscribing to topics.
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL81-R89): Added a constructor `new` for `MqttSubscribe` to simplify the creation of subscribe packets.

### Enhancements:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL3-L74): Refactored the main function to use the new `subscribe_to_topic` function, improving readability and maintainability. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL3-L74) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR53-L102)
* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R21-R72): Improved error handling for reading SUBACK packets and added a timeout mechanism.

### Code Cleanup:
* [`src/packet.rs`](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL2-R3): Removed unused imports and added comments for better code documentation. [[1]](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL2-R3) [[2]](diffhunk://#diff-3c39415a3b97f6bcbed861b337766f7b34a59b892132ac63f265cc7d0937a48bL187-R192)

These changes collectively enhance the functionality and robustness of the MQTT client.